### PR TITLE
Fix #13; package management should be optional

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,3 +4,4 @@ puppetagent::agent_version: 'installed'
 puppetagent::agent_server: 'puppetserver.hacklab'
 puppetagent::agent_environment: 'production'
 puppetagent::agent_runinterval: 3600
+puppetagent::manage_package: true

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,4 +1,4 @@
-# Puppetsagent calss.
+# Puppetagent class.
 #
 # This is a class to install and manage PuppetAgent:
 #
@@ -10,14 +10,16 @@
 # @param [String] agent_environment Set the environment for puppet-agent
 # @param [Integer] agent_runinterval Set the interval between agent runs
 # @param [String] agent_server Set the puppet server for the agent
-
-class puppetagent(
+# @param [Boolean] manage_package Enable the agent package management. Default: true
+#
+class puppetagent (
   String $agent_certname,
   String $agent_version,
   String $agent_environment,
   Integer $agent_runinterval,
   String $agent_server,
-  ) {
+  Boolean $manage_package = true,
+) {
 
   include puppetagent::install
   include puppetagent::config

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,7 +1,11 @@
-# docs
+# Internal class.
+#
+# This class can manage the Puppet Agent package version, if required.
+# It should not be used directly.
+#
 class puppetagent::install {
 
-  if 'Linux' == $facts['kernel'] {
+  if $puppetagent::manage_package and 'Linux' == $facts['kernel'] {
     package { 'puppet-agent':
       ensure => $puppetagent::agent_version,
     }


### PR DESCRIPTION
This changes allow the module to not manage the Puppet Agent OS package,
when a flag is turned off. The default is to manage the package version.