### PR TITLE
Fix #16; update default agent version

### DIFF
--- a/data/oses/distro/CentOS/5.yaml
+++ b/data/oses/distro/CentOS/5.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el5'
+puppetagent::agent_version: '5.5.4-1.el5'

--- a/data/oses/distro/CentOS/5.yaml
+++ b/data/oses/distro/CentOS/5.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el5'
+puppetagent::agent_version: '5.5.6-1.el5'

--- a/data/oses/distro/CentOS/6.yaml
+++ b/data/oses/distro/CentOS/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el6'
+puppetagent::agent_version: '5.5.4-1.el6'

--- a/data/oses/distro/CentOS/6.yaml
+++ b/data/oses/distro/CentOS/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el6'
+puppetagent::agent_version: '5.5.6-1.el6'

--- a/data/oses/distro/CentOS/7.yaml
+++ b/data/oses/distro/CentOS/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el7'
+puppetagent::agent_version: '5.5.6-1.el7'

--- a/data/oses/distro/CentOS/7.yaml
+++ b/data/oses/distro/CentOS/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el7'
+puppetagent::agent_version: '5.5.4-1.el7'

--- a/data/oses/distro/Debian/7.yaml
+++ b/data/oses/distro/Debian/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1wheezy'
+puppetagent::agent_version: '5.5.6-1wheezy'

--- a/data/oses/distro/Debian/7.yaml
+++ b/data/oses/distro/Debian/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1wheezy'
+puppetagent::agent_version: '5.5.4-1wheezy'

--- a/data/oses/distro/Debian/8.yaml
+++ b/data/oses/distro/Debian/8.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1jessie'
+puppetagent::agent_version: '5.5.4-1jessie'

--- a/data/oses/distro/Debian/8.yaml
+++ b/data/oses/distro/Debian/8.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1jessie'
+puppetagent::agent_version: '5.5.6-1jessie'

--- a/data/oses/distro/Debian/9.yaml
+++ b/data/oses/distro/Debian/9.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1stretch'
+puppetagent::agent_version: '5.5.6-1stretch'

--- a/data/oses/distro/Debian/9.yaml
+++ b/data/oses/distro/Debian/9.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1stretch'
+puppetagent::agent_version: '5.5.4-1stretch'

--- a/data/oses/distro/OracleLinux/5.yaml
+++ b/data/oses/distro/OracleLinux/5.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el5'
+puppetagent::agent_version: '5.5.4-1.el5'

--- a/data/oses/distro/OracleLinux/5.yaml
+++ b/data/oses/distro/OracleLinux/5.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el5'
+puppetagent::agent_version: '5.5.6-1.el5'

--- a/data/oses/distro/OracleLinux/6.yaml
+++ b/data/oses/distro/OracleLinux/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el6'
+puppetagent::agent_version: '5.5.4-1.el6'

--- a/data/oses/distro/OracleLinux/6.yaml
+++ b/data/oses/distro/OracleLinux/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el6'
+puppetagent::agent_version: '5.5.6-1.el6'

--- a/data/oses/distro/OracleLinux/7.yaml
+++ b/data/oses/distro/OracleLinux/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el7'
+puppetagent::agent_version: '5.5.6-1.el7'

--- a/data/oses/distro/OracleLinux/7.yaml
+++ b/data/oses/distro/OracleLinux/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el7'
+puppetagent::agent_version: '5.5.4-1.el7'

--- a/data/oses/distro/SLES/11.yaml
+++ b/data/oses/distro/SLES/11.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.sles11'
+puppetagent::agent_version: '5.5.6-1.sles11'

--- a/data/oses/distro/SLES/11.yaml
+++ b/data/oses/distro/SLES/11.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.sles11'
+puppetagent::agent_version: '5.5.4-1.sles11'

--- a/data/oses/distro/SLES/12.yaml
+++ b/data/oses/distro/SLES/12.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.sles12'
+puppetagent::agent_version: '5.5.6-1.sles12'

--- a/data/oses/distro/SLES/12.yaml
+++ b/data/oses/distro/SLES/12.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.sles12'
+puppetagent::agent_version: '5.5.4-1.sles12'

--- a/data/oses/distro/Scientific/6.yaml
+++ b/data/oses/distro/Scientific/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el6'
+puppetagent::agent_version: '5.5.4-1.el6'

--- a/data/oses/distro/Scientific/6.yaml
+++ b/data/oses/distro/Scientific/6.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el6'
+puppetagent::agent_version: '5.5.6-1.el6'

--- a/data/oses/distro/Scientific/7.yaml
+++ b/data/oses/distro/Scientific/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1.el7'
+puppetagent::agent_version: '5.5.6-1.el7'

--- a/data/oses/distro/Scientific/7.yaml
+++ b/data/oses/distro/Scientific/7.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1.el7'
+puppetagent::agent_version: '5.5.4-1.el7'

--- a/data/oses/distro/Ubuntu/14.04.yaml
+++ b/data/oses/distro/Ubuntu/14.04.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1trusty'
+puppetagent::agent_version: '5.5.4-1trusty'

--- a/data/oses/distro/Ubuntu/14.04.yaml
+++ b/data/oses/distro/Ubuntu/14.04.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1trusty'
+puppetagent::agent_version: '5.5.6-1trusty'

--- a/data/oses/distro/Ubuntu/16.04.yaml
+++ b/data/oses/distro/Ubuntu/16.04.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.4-1xenial'
+puppetagent::agent_version: '5.5.6-1xenial'

--- a/data/oses/distro/Ubuntu/16.04.yaml
+++ b/data/oses/distro/Ubuntu/16.04.yaml
@@ -1,1 +1,1 @@
-puppetagent::agent_version: '5.5.3-1xenial'
+puppetagent::agent_version: '5.5.4-1xenial'


### PR DESCRIPTION
This changes updates the default Puppet agent version to 5.5.4.