### PR TITLE
Fix #18; add support to Windows agent

### DIFF
--- a/.fixtures
+++ b/.fixtures
@@ -1,3 +1,0 @@
-fixtures:
-  symlinks:
-    "puppetagent": "#{source_dir}

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,5 @@
+fixtures:
+  symlinks:
+    puppetagent: '#{source_dir}'
+  forge_modules:
+    inifile: 'puppetlabs/inifile'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next Relesase
+
+**Features**
+
+- Added support to Windows Server 2016
+- Added support to Windows Server 2012 R2
+- Added support to Windows Server 2008 R2
+
 ## Relesase 2.0.0
+
+**Features**
 
 - Added support to SLES 11
 - Added support to SLES 12

--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ This module was tested under these platforms
 - Debian 7, 8 and 9
 - Ubuntu 14.04 and 16.04
 - SLES 11 and 12
+- Windows Server 2008 R2, 2012 R2 and 2016
 
-Tested only in X86_64 arch.  
+Tested only in x86_64 arch.
 
 ## Requirements
 
@@ -338,7 +339,7 @@ Our matrix values
     ubuntu-1604-x64
     sles-11-x64
     sles-12-x64
-   
+
 This matrix needs vagrant (>=2.0) and virtualbox (>=5.1) to work properly, make sure that you have both of them installed.
 
 ### Author

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,24 +1,70 @@
 # docs
 class puppetagent::config {
 
-  augeas {'agent_certname':
-    context => '/files/etc/puppetlabs/puppet/puppet.conf',
-    changes => [ "set main/certname ${puppetagent::agent_certname}", ],
+  if 'Linux' == $facts['kernel'] {
+
+    Augeas {
+      context => '/files/etc/puppetlabs/puppet/puppet.conf',
+      notify  => Service['puppet'],
+    }
+
+    augeas { 'agent_certname':
+      changes => [ "set main/certname ${puppetagent::agent_certname}", ],
+    }
+
+    augeas { 'agent_server':
+      changes => [ "set main/server ${puppetagent::agent_server}", ],
+    }
+
+    augeas { 'agent_environment':
+      changes => [ "set main/environment ${puppetagent::agent_environment}", ],
+    }
+
+    augeas { 'agent_runinterval':
+      changes => [ "set main/runinterval ${puppetagent::agent_runinterval}", ],
+    }
   }
 
-  augeas {'agent_server':
-    context => '/files/etc/puppetlabs/puppet/puppet.conf',
-    changes => [ "set main/server ${puppetagent::agent_server}", ],
-  }
+  if 'windows' == $facts['kernel'] {
 
-  augeas {'agent_environment':
-    context => '/files/etc/puppetlabs/puppet/puppet.conf',
-    changes => [ "set main/environment ${puppetagent::agent_environment}", ],
-  }
+    $version = $::facts['os']['release']['major']
+    case $version {
+      '2003', '2003 R2': {
+        $puppet_conf = 'c:/Documents and Settings/All Users/Application Data/PuppetLabs/puppet/etc/puppet.conf'
+      }
+      '2008', '2008 R2', '2012', '2012 R2', '2016': {
+        $puppet_conf = 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf'
+      }
+      default: {
+        $puppet_conf = 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf'
+      }
+    }
 
-  augeas {'agent_runinterval':
-    context => '/files/etc/puppetlabs/puppet/puppet.conf',
-    changes => [ "set main/runinterval ${puppetagent::agent_runinterval}", ],
+    Ini_setting {
+      path    => $puppet_conf,
+      section => 'main',
+      notify  => Service['puppet']
+    }
+
+    ini_setting { 'agent_certname':
+      setting => 'certname',
+      value   => $puppetagent::agent_certname,
+    }
+
+    ini_setting { 'agent_server':
+      setting => 'server',
+      value   => $puppetagent::agent_server,
+    }
+
+    ini_setting { 'agent_environment':
+      setting => 'environment',
+      value   => $puppetagent::agent_environment,
+    }
+
+    ini_setting { 'agent_runinterval':
+      setting => 'runinterval',
+      value   => $puppetagent::agent_runinterval,
+    }
   }
 
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,8 +1,10 @@
 # docs
 class puppetagent::install {
 
-  package { 'puppet-agent':
-    ensure => $puppetagent::agent_version,
+  if 'Linux' == $facts['kernel'] {
+    package { 'puppet-agent':
+      ensure => $puppetagent::agent_version,
+    }
   }
 
 }

--- a/metadata.json
+++ b/metadata.json
@@ -8,12 +8,14 @@
   "project_page": "https://github.com/instruct-br/puppet-puppetagent",
   "issues_url": "https://github.com/instruct-br/puppet-puppetagent/issues",
   "dependencies": [
-
+    {
+      "name": "puppetlabs/inifile",
+      "version_requirement": ">= 2.2.0"
+    }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "RedHat",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "5",
         "6",
@@ -22,7 +24,6 @@
     },
     {
       "operatingsystem": "Scientific",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "5",
         "6",
@@ -31,7 +32,6 @@
     },
     {
       "operatingsystem": "Oracle",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "5",
         "6",
@@ -40,7 +40,6 @@
     },
     {
       "operatingsystem": "CentOS",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "5",
         "6",
@@ -49,7 +48,6 @@
     },
     {
       "operatingsystem": "Ubuntu",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "14.04",
         "16.04"
@@ -57,7 +55,6 @@
     },
     {
       "operatingsystem": "Suse",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "11",
         "12"
@@ -65,11 +62,18 @@
     },
     {
       "operatingsystem": "Debian",
-      "architecture": "x86_64",
       "operatingsystemrelease": [
         "7",
         "8",
         "9"
+      ]
+    },
+    {
+      "operatingsystem": "Windows",
+      "operatingsystemrelease": [
+        "Server 2008 R2",
+        "Server 2012 R2",
+        "Server 2016"
       ]
     }
   ],

--- a/spec/classes/puppetagent_spec.rb
+++ b/spec/classes/puppetagent_spec.rb
@@ -14,24 +14,42 @@ describe 'puppetagent', :type => :class do
       it { is_expected.to contain_class('puppetagent::config').that_comes_before('Class[puppetagent::service]') }
       it { is_expected.to contain_class('puppetagent::service') }
 
-
       context 'puppetserver::install' do
-        it { is_expected.to contain_package('puppet-agent') }
+        case facts[:kernel]
+        when 'Linux'
+          it { is_expected.to contain_package('puppet-agent') }
+        end
       end
 
       context 'puppetserver::config' do
-        it { is_expected.to contain_augeas('agent_certname').with({
-          'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
-        })}
-        it { is_expected.to contain_augeas('agent_server').with({
-          'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
-        })}
-        it { is_expected.to contain_augeas('agent_runinterval').with({
-          'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
-        })}
-        it { is_expected.to contain_augeas('agent_environment').with({
-          'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
-        })}
+        case facts[:kernel]
+        when 'Linux'
+          it { is_expected.to contain_augeas('agent_certname').with({
+            'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
+          })}
+          it { is_expected.to contain_augeas('agent_server').with({
+            'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
+          })}
+          it { is_expected.to contain_augeas('agent_runinterval').with({
+            'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
+          })}
+          it { is_expected.to contain_augeas('agent_environment').with({
+            'context' => '/files/etc/puppetlabs/puppet/puppet.conf',
+          })}
+        when 'windows'
+          it { is_expected.to contain_ini_setting('agent_certname').with({
+            'path' => 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
+          })}
+          it { is_expected.to contain_ini_setting('agent_server').with({
+            'path' => 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
+          })}
+          it { is_expected.to contain_ini_setting('agent_runinterval').with({
+            'path' => 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
+          })}
+          it { is_expected.to contain_ini_setting('agent_environment').with({
+            'path' => 'c:/ProgramData/PuppetLabs/puppet/etc/puppet.conf',
+          })}
+        end
       end
 
       context 'puppetserver::service' do


### PR DESCRIPTION
This changes allow Windows (2008, 2012 and 2016 versions) Puppet agents
to be configured and managed remotely.